### PR TITLE
"Optimize socket connection handling and add socket timeout configuration"

### DIFF
--- a/backend/src/core/environment/environment.ts
+++ b/backend/src/core/environment/environment.ts
@@ -22,6 +22,7 @@ export class Environment implements IEnvironment {
   };
   public readonly charset: string;
   public readonly projectRoot: string;
+  public readonly socketTimeout: number;
 
   /**
    * Private constructor to enforce singleton pattern.
@@ -50,6 +51,10 @@ export class Environment implements IEnvironment {
     this.telnetPort = Number(getEnvironmentVariable('TELNET_PORT'));
 
     this.charset = String(getEnvironmentVariable('CHARSET', false, 'utf8'));
+
+    this.socketTimeout = Number(
+      getEnvironmentVariable('SOCKET_TIMEOUT', false, '900000'),
+    );
 
     this.projectRoot = resolveModulePath('../../../main.js');
 

--- a/backend/src/core/environment/environment.ts
+++ b/backend/src/core/environment/environment.ts
@@ -58,7 +58,7 @@ export class Environment implements IEnvironment {
 
     this.projectRoot = resolveModulePath('../../../main.js');
 
-    logger.info('Environment initialized:', this);
+    logger.info('[Environment] initialized', this);
   }
 
   /**

--- a/backend/src/core/environment/types/environment-keys.ts
+++ b/backend/src/core/environment/types/environment-keys.ts
@@ -3,6 +3,7 @@ export type EnvironmentKeys =
   | 'PORT'
   | 'TELNET_HOST'
   | 'TELNET_PORT'
+  | 'SOCKET_TIMEOUT' // in milliseconds | default: 900000 (15 min) | determines how long messages are buffed for the disconnected frontend and when the telnet connection is closed
   | 'TLS'
   | 'TLS_CERT'
   | 'TLS_KEY'

--- a/backend/src/core/environment/types/environment.ts
+++ b/backend/src/core/environment/types/environment.ts
@@ -11,6 +11,8 @@ export interface IEnvironment {
 
   readonly charset: string;
 
+  readonly socketTimeout: number;
+
   // backend: {
   //   host: string;
   //   port: number;

--- a/backend/src/core/sockets/socket-manager.ts
+++ b/backend/src/core/sockets/socket-manager.ts
@@ -4,12 +4,11 @@ import { Server, Socket } from 'socket.io';
 
 import { TelnetClient } from '../../features/telnet/telnet-client.js';
 import { logger } from '../../shared/utils/logger.js';
+import { Environment } from '../environment/environment.js';
 import { ClientToServerEvents } from './types/client-to-server-events.js';
 import { InterServerEvents } from './types/inter-server-events.js';
 import { MudConnections } from './types/mud-connections.js';
 import { ServerToClientEvents } from './types/server-to-client-events.js';
-
-const CONNECTION_TIMEOUT = 60 * 3 * 1000; //900_000; // 15 minutes
 
 export class SocketManager extends Server<
   ClientToServerEvents,
@@ -30,7 +29,7 @@ export class SocketManager extends Server<
       path: '/socket.io',
       transports: ['websocket'],
       connectionStateRecovery: {
-        maxDisconnectionDuration: CONNECTION_TIMEOUT,
+        maxDisconnectionDuration: Environment.getInstance().socketTimeout,
       },
     });
 
@@ -93,7 +92,7 @@ export class SocketManager extends Server<
       });
 
       logger.info(
-        `[Socket-Manager] [Client] ${socket.id} starting timer to close telnet connection in ${CONNECTION_TIMEOUT}ms`,
+        `[Socket-Manager] [Client] ${socket.id} starting timer to close telnet connection in ${Environment.getInstance().socketTimeout}ms`,
         {
           socketId: socket.id,
         },
@@ -101,7 +100,7 @@ export class SocketManager extends Server<
 
       this.mudConnections[socket.id].timer = setTimeout(() => {
         this.closeTelnetConnections(socket.id);
-      }, CONNECTION_TIMEOUT);
+      }, Environment.getInstance().socketTimeout);
     });
 
     socket.on('mudInput', (data: string) => {

--- a/backend/src/core/sockets/socket-manager.ts
+++ b/backend/src/core/sockets/socket-manager.ts
@@ -63,10 +63,10 @@ export class SocketManager extends Server<
           },
         );
 
-        if (this.mudConnections[socket.id].timer !== undefined) {
-          clearTimeout(this.mudConnections[socket.id].timer);
+        if (this.mudConnections[socket.id].connectionTimer !== undefined) {
+          clearTimeout(this.mudConnections[socket.id].connectionTimer);
 
-          this.mudConnections[socket.id].timer = undefined;
+          this.mudConnections[socket.id].connectionTimer = undefined;
         }
       }
     });
@@ -98,7 +98,7 @@ export class SocketManager extends Server<
         },
       );
 
-      this.mudConnections[socket.id].timer = setTimeout(() => {
+      this.mudConnections[socket.id].connectionTimer = setTimeout(() => {
         this.closeTelnetConnections(socket.id);
       }, Environment.getInstance().socketTimeout);
     });
@@ -159,7 +159,7 @@ export class SocketManager extends Server<
 
         this.mudConnections[socket.id] = {
           telnet: telnetClient,
-          timer: undefined,
+          connectionTimer: undefined,
         };
 
         logger.info(

--- a/backend/src/core/sockets/types/mud-connections.ts
+++ b/backend/src/core/sockets/types/mud-connections.ts
@@ -3,6 +3,6 @@ import { TelnetClient } from '../../../features/telnet/telnet-client.js';
 export type MudConnections = {
   [socketId: string]: {
     telnet: TelnetClient | undefined;
-    timer: NodeJS.Timeout | undefined;
+    connectionTimer: NodeJS.Timeout | undefined;
   };
 };

--- a/backend/src/core/sockets/types/mud-connections.ts
+++ b/backend/src/core/sockets/types/mud-connections.ts
@@ -3,5 +3,6 @@ import { TelnetClient } from '../../../features/telnet/telnet-client.js';
 export type MudConnections = {
   [socketId: string]: {
     telnet: TelnetClient | undefined;
+    timer: NodeJS.Timeout | undefined;
   };
 };

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -14,8 +14,6 @@ sourceMaps.install();
 
 const environment = Environment.getInstance();
 
-logger.info('[Main] Environment loaded', { environment });
-
 const app = express();
 
 const UNIQUE_SERVER_ID = uuidv4();

--- a/frontend/src/app/core/mud/components/mud-output/mud-output.component.ts
+++ b/frontend/src/app/core/mud/components/mud-output/mud-output.component.ts
@@ -61,13 +61,6 @@ export class MudOutputComponent implements AfterViewChecked, AfterViewInit {
         element.scrollHeight - element.scrollTop - element.clientHeight,
       ) <= tolerance;
 
-    console.log('Test', {
-      scrollTop: element.scrollTop,
-      scrollHeight: element.scrollHeight,
-      clientHeight: element.clientHeight,
-      atBottom,
-    });
-
     this.canScrollToBottom = atBottom;
   }
 

--- a/frontend/src/app/core/mud/mud-client/mud-client.component.html
+++ b/frontend/src/app/core/mud/mud-client/mud-client.component.html
@@ -1,13 +1,20 @@
-<app-mud-menu
-  (connectClicked)="this.onConnectClicked()"
-  (disconnectClicked)="this.onDisconnectClicked()"
-></app-mud-menu>
 <app-mud-output
   *ngIf="this.output$ | async as lines"
   [lines]="lines"
   [foregroundColor]="this.v.stdfg"
   [backgroundColor]="this.v.stdbg"
 ></app-mud-output>
-<app-mud-input (messageSent)="onInputReceived($event)"></app-mud-input>
+
+<ng-container *ngIf="this.isConnected$ | async; else disconnected">
+  <app-mud-input (messageSent)="onInputReceived($event)"></app-mud-input>
+</ng-container>
+
+<ng-template #disconnected>
+  <div id="disconnected-panel">
+    <p>Disconnected!</p>
+    <p-button label="reconnect" (click)="this.onConnectClicked()"></p-button>
+  </div>
+</ng-template>
+
 <!--<p-divider layout="vertical"></p-divider>
   <app-inventory [inv]="invlist" [vheight]="v.ref_height"></app-inventory>-->

--- a/frontend/src/app/core/mud/mud-client/mud-client.component.scss
+++ b/frontend/src/app/core/mud/mud-client/mud-client.component.scss
@@ -32,4 +32,12 @@
     display: flex;
     flex-direction: column;
   }
+
+  #disconnected-panel {
+    display: flex;
+    gap: 32px;
+    padding: 4px;
+    align-items: center;
+    align-self: center;
+  }
 }

--- a/frontend/src/app/core/mud/mud-client/mud-client.component.ts
+++ b/frontend/src/app/core/mud/mud-client/mud-client.component.ts
@@ -19,8 +19,10 @@ import { IMudMessage } from '../types/mud-message';
 export class MudclientComponent {
   protected readonly output$: Observable<IMudMessage[]>;
 
-  @ViewChild(MudInputComponent, { static: true })
-  private mudInputComponent!: MudInputComponent;
+  protected readonly isConnected$: Observable<boolean>;
+
+  @ViewChild(MudInputComponent, { static: false })
+  private mudInputComponent?: MudInputComponent;
 
   public v = {
     scrollLock: true,
@@ -50,6 +52,10 @@ export class MudclientComponent {
   ) {
     this.output$ = this.mudService.outputLines$;
 
+    this.isConnected$ = this.mudService.connectedToMud$;
+
+    this.mudService.connect();
+
     this.invlist = new InventoryList();
 
     // Todo[myst]: Herausfinden, was der cookieService alles unter 'mudcolors' gespeichert hat
@@ -66,9 +72,9 @@ export class MudclientComponent {
     // }
   }
 
-  protected onDisconnectClicked() {
-    this.mudService.disconnect();
-  }
+  // protected onDisconnectClicked() {
+  //   this.mudService.disconnect();
+  // }
 
   protected onConnectClicked() {
     this.mudService.connect();
@@ -91,7 +97,7 @@ export class MudclientComponent {
       !event.metaKey &&
       !event.key.includes('Tab')
     ) {
-      this.mudInputComponent.focus();
+      this.mudInputComponent?.focus();
     }
   }
 

--- a/frontend/src/app/features/sockets/sockets.service.ts
+++ b/frontend/src/app/features/sockets/sockets.service.ts
@@ -38,10 +38,9 @@ export class SocketsService {
     this.manager = new Manager(socketUrl, {
       path: socketNamespace,
       transports: ['websocket'],
+      reconnectionAttempts: Infinity,
+      reconnection: true,
     });
-
-    this.manager.reconnection(true);
-    this.manager.reconnectionAttempts(10);
 
     this.manager.on('error', (error: Error) => {
       this.handleError(error);
@@ -61,6 +60,10 @@ export class SocketsService {
 
     this.manager.on('reconnect_failed', () => {
       this.handleReconnectFailed();
+    });
+
+    this.manager.on('close', () => {
+      this.handleClose();
     });
 
     this.manager.on('ping', () => {
@@ -117,6 +120,8 @@ export class SocketsService {
   };
 
   private handleMudDisconnect = () => {
+    console.log(`[Sockets] Socket Service received 'mudDisconnected'`);
+
     this.connectedToMud.next(false);
 
     this.onMudDisconnect.emit();
@@ -127,6 +132,14 @@ export class SocketsService {
       data: output,
     });
   };
+
+  private handleClose() {
+    console.log('[Sockets] Socket Service Close');
+
+    this.connectedToMud.next(false);
+
+    this.onMudConnect.emit();
+  }
 
   private handleError = (error: Error) => {
     console.error('[Sockets] Socket Service Error:', error);

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -6,7 +6,8 @@ import { Environment } from './environment.interface';
 
 export const environment: Environment = {
   production: false,
-  backendUrl: () => window.location.origin,
+  // Change this to your local IP if you want to test on a mobile device in the same network
+  backendUrl: () => 'http://localhost:5000',
 };
 
 /*

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -6,7 +6,7 @@ import { Environment } from './environment.interface';
 
 export const environment: Environment = {
   production: false,
-  backendUrl: () => 'http://192.168.178.76:5000',
+  backendUrl: () => window.location.origin,
 };
 
 /*


### PR DESCRIPTION
This pull request includes the following changes:

- Refactored the backend to optimize socket connection handling by implementing a connection timeout of 15 minutes. This ensures that idle connections are closed after a certain period of inactivity.

- Added a new configuration option `SOCKET_TIMEOUT` to the backend environment. The `SOCKET_TIMEOUT` determines the duration in milliseconds after which idle socket connections are closed. The default value for `SOCKET_TIMEOUT` is set to 900000 (15 minutes).

- Cleaned up the backend and improved the UI for the disconnected state in the frontend.

- Fixed an issue in the frontend where localhost settings were being removed by default.

Fixes #42